### PR TITLE
Muted state fix

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -258,7 +258,7 @@ DM.provide('Player',
             case 'seeking': this.seeking = true; this.currentTime = parseFloat(event.time); break;
             case 'seeked': this.seeking = false; this.currentTime = parseFloat(event.time); break;
             case 'fullscreenchange': this.fullscreen = DM.parseBool(event.fullscreen); break;
-            case 'volumechange': this.volume = parseFloat(event.volume); break;
+            case 'volumechange': this.volume = parseFloat(event.volume); this.muted = DM.parseBool(event.muted); break;
             case 'playing':
             case 'play': this.paused = false; break;
             case 'ended': this.ended = true; break; // no break, also set paused


### PR DESCRIPTION
Fix to be able to pass falsy arguments when using player methods for example : setMuted(0) + updating the state of the muted property when "volumechange" event is triggered.
