### PR TITLE
[API] add nested request support through fields array notation

### DIFF
--- a/src/common/array.js
+++ b/src/common/array.js
@@ -77,6 +77,27 @@ DM.provide('Array',
     },
 
     /**
+     * flatten arrays of strings in obj to one string concatenated with comma.
+     *
+     * @param arr {Object} Object to flatten.
+     * @return {Object} Flattened object.
+     */
+    flatten: function(obj)
+    {
+        for (var param in obj)
+        {
+            if (obj.hasOwnProperty(param))
+            {
+                if (DM.type(obj[param]) == 'array')
+                {
+                    obj[param] = obj[param].join(',');
+                }
+            }
+        }
+        return obj;
+    },
+
+    /**
      * Create an new array from the given array and a filter function.
      *
      * @param arr {Array} Source array.

--- a/tests/index.html
+++ b/tests/index.html
@@ -53,7 +53,7 @@ var action = document.getElementById('action');
 <script src="js/json.js"></script>
 <script src="js/event.js"></script>
 <script src="js/cookie.js"></script>
-<!--<script src="js/api.js"></script>-->
+<script src="js/api.js"></script>
 
 <!-- tests that require user interaction: -->
 <script src="js/auth.js"></script>

--- a/tests/js/api.js
+++ b/tests/js/api.js
@@ -1,0 +1,91 @@
+module('api');
+
+test('API calls "fields" should be string or array', function()
+{
+    DM.api('/playlists', { limit: 3, fields: 'id,uri,name,videos_total' });
+    ok(true, 'Allow call with fields as string');
+    DM.api('/playlists', { limit: 3, fields: ['id','uri','name','videos_total']});
+    ok(true, 'Allow call with fields as array');
+
+    var  testMessage;
+
+    testMessage = 'Disallow call with fields as object';
+    try
+    {
+        DM.api('/playlists', { limit: 3, fields: {}});
+        ok(false, testMessage);
+    }
+    catch(e)
+    {
+        ok(true, testMessage);
+    }
+
+    testMessage = 'Allow call without fields';
+    try
+    {
+        DM.api('/playlists');
+        ok(true, testMessage);
+    }
+    catch(e)
+    {
+        ok(false, testMessage);
+    }
+
+    testMessage = 'Allow call with empty fields as array';
+    try
+    {
+        DM.api('/playlists', {fields: []});
+        ok(true, testMessage);
+    }
+    catch(e)
+    {
+        ok(false, testMessage);
+    }
+
+    testMessage = 'Allow call with empty fields as string';
+    try
+    {
+        DM.api('/playlists', {fields: ''});
+        ok(true, testMessage);
+    }
+    catch(e)
+    {
+        ok(false, testMessage);
+    }
+});
+
+test('API calls "subrequests" should be object', function()
+{
+    testMessage = 'Allow call with subrequests as object';
+    DM.api('/playlists',
+        {
+            fields: 'id,uri,name,videos_total', 
+            subrequests:
+            {
+                'videos':
+                {
+                    fields: ['thumbnail_120_url'],
+                    limit: 4
+                }
+            }
+        }
+    );
+    ok(true, testMessage);
+
+    testMessage = 'Disallow call with subrequests as string';
+    try
+    {
+        DM.api('/playlists',
+            {
+                fields: 'id,uri,name,videos_total', 
+                subrequests: 'videos.fields(thumbnail_120_url).limit(4)'
+            }
+        );
+        ok(false, testMessage);
+    }
+    catch(e)
+    {
+        ok(true, testMessage);
+    }
+});
+

--- a/tests/js/cookie.js
+++ b/tests/js/cookie.js
@@ -33,7 +33,6 @@ test('set a cookie, load and delete it', function()
         answer: 42
     });
     ok(document.cookie.match('dms_' + cookieApiKey), 'found in document.cookie');
-    console.log(DM.Cookie.load());
     ok(DM.Cookie.load().answer == 42, 'found the answer');
     DM.Cookie.clear();
     ok(!document.cookie.match('dms_' + cookieApiKey), 'not found in document.cookie');


### PR DESCRIPTION
- Add ajax simple call (instead of multicall with one call) suport when bypassing multicall
- Invert multicall bypass parameter (DM.api(..., false) become (DM.api(..., true))
- Add few API tests to ensure support for nested request and fields syntax
