### PR TITLE
[API] fix exception triggered when API Response HTTP Code != 200

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -398,9 +398,12 @@ DM.provide('ApiServer',
                 var globalError = {error: {code: 500, message: 'Invalid server response', type: 'transport_error'}},
                     response;
 
-                if (xhr.status == 200)
+                if (xhr.status)
                 {
-                    response = DM.JSON.parse(xhr.responseText);
+                    try
+                    {
+                        response = DM.JSON.parse(xhr.responseText);
+                    } catch(e) {}
                 }
 
                 if (DM.type(response) != 'object')
@@ -452,12 +455,17 @@ DM.provide('ApiServer',
                 var globalError = {error: {code: 500, message: 'Invalid server response', type: 'transport_error'}},
                     responses;
 
-                if (xhr.status == 200)
+                if (xhr.status)
                 {
-                    responses = DM.JSON.parse(xhr.responseText);
+                    try
+                    {
+                        responses = DM.JSON.parse(xhr.responseText);
+                    } catch(e) {}
                 }
 
-                if (DM.type(responses) == 'array')
+                var responseType = DM.type(responses);
+
+                if (responseType == 'array')
                 {
                     for (var i = 0, l = responses.length; i < l; i++)
                     {
@@ -488,7 +496,7 @@ DM.provide('ApiServer',
                         calls[response.id] = null;
                     }
                 }
-                else if (DM.type(responses) == 'object' && 'error' in responses)
+                else if (responseType == 'object' && 'error' in responses)
                 {
                     // Global error
                     globalError = responses;

--- a/src/core/prelude.js
+++ b/src/core/prelude.js
@@ -252,6 +252,7 @@ if (!window.DM)
                     var name = classes[i];
                     DM._class2type['[object ' + name + ']'] = name.toLowerCase();
                 }
+                DM._class2type['[object Undefined]'] = 'undefined';
             }
             return obj === null ? String(obj) : DM._class2type[Object.prototype.toString.call(obj)] || "object";
         }


### PR DESCRIPTION
When calling the API through the SDK using AJAX, if the response HTTP response code is != 200 an error occurs.

Since the API may return response in various HTTP code (200, 401, ...) we should not focus only on "200" responses.
