### PR TITLE
[PLAYER] Serialize postMessage communication

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -201,10 +201,10 @@ DM.provide('Player',
     {
         if (DM.Player.API_MODE == 'postMessage')
         {
-            this.contentWindow.postMessage({
+            this.contentWindow.postMessage(JSON.stringify({
                 command    : command,
                 parameters : parameters || []
-            }, DM.Player._PROTOCOL + DM._domain.www);
+            }), DM.Player._PROTOCOL + DM._domain.www);
         }
     },
 

--- a/tests/player.html
+++ b/tests/player.html
@@ -106,7 +106,7 @@ $('input[type=button]').click(function()
         if (!arg) return;
     }
     $('<li class=out>&lt;- ' + cmd + (arg ? '=' + arg : '') + '</li>').prependTo('#console');
-    params = [cmd, arg];
+    params = (!arg) ? [cmd] : [cmd, arg];
 
     if (cmd === 'load' && !$('input[name=autoplay]').is(':checked'))
     {


### PR DESCRIPTION
`postMessage` communication with the player `iframe`must rely on strings instead of object literals to work with IE.