### PR TITLE
Add controls in player API

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -60,6 +60,7 @@ DM.provide('Player',
     volume: 1,
     paused: true,
     fullscreen: false,
+    controls: undefined,
     rebuffering: false,
     qualities: [],
     quality: undefined,
@@ -77,6 +78,8 @@ DM.provide('Player',
     setQuality: function(quality) {this.api('quality', quality);},
     setSubtitle: function(subtitle) {this.api('subtitle', subtitle);},
     setFullscreen: function(fullscreen) {this.api('fullscreen', fullscreen);},
+    setControls: function (visible) { this.api('controls', visible);},
+    toggleControls: function () { this.api('toggle-controls');},
     setProp: function() {this.api.apply(this, ['set-prop'].concat([].slice.call(arguments)));}, // onsite use only
     watchOnSite: function(muted) {this.api('watch-on-site');},
 
@@ -246,6 +249,7 @@ DM.provide('Player',
             case 'seeking': this.seeking = true; this.currentTime = parseFloat(event.time); break;
             case 'seeked': this.seeking = false; this.currentTime = parseFloat(event.time); break;
             case 'fullscreenchange': this.fullscreen = DM.parseBool(event.fullscreen); break;
+            case 'controlschange': this.controls = DM.parseBool(event.controls); break;
             case 'volumechange': this.volume = parseFloat(event.volume); this.muted = DM.parseBool(event.muted); break;
             case 'video_start':
             case 'ad_start':

--- a/tests/player.html
+++ b/tests/player.html
@@ -20,7 +20,7 @@ input {font-size: 20px; border: 1px solid #333; background: #fff; margin-left: 0
 input[type=button]:hover {background: #efefef}
 #player {height: 350px; width: 100%}
 #progress, #duration {width: 80px; text-align:center}
-#console {position: absolute; min-height: 300px; top: 500px; bottom: 0; width: 100%; margin: 0; overflow: auto; list-style-type: none; padding: 5px; background: #eee}
+#console {position: absolute; min-height: 300px; top: 530px; bottom: 0; width: 100%; margin: 0; overflow: auto; list-style-type: none; padding: 5px; background: #eee}
 #console li {padding: 2px; font-family: courier; font-size: 18px}
 .in {color: #232295} .out {color: #d05c00} .minor {color: #ccc} .info {color: #00a3bc} .fatal {color: #ff3333}
 #console.hide-minor .minor {display: none}
@@ -48,6 +48,10 @@ input[type=button]:hover {background: #efefef}
 <input type=button value=mute>
 <input type=button value=unmute>
 <input type=button value=volume prompt="Volume" default=1>
+</div>
+<div>
+<input type=button value=toggle-controls>
+<input type=button value="controls" prompt="Controls" default=1>
 </div>
 <div>
 <input id="progress" value="--:--">
@@ -114,7 +118,7 @@ $('input[type=button]').click(function()
     }
     player.api.apply(player, params);
 });
-$(player).bind( 'apiready play playing canplay canplaythrough loadedmetadata timeupdate progress seeking seeked volumechange durationchange pause start end video_start video_end ended error fullscreenchange qualitiesavailable qualitychange subtitlesavailable subtitlechange ad_start ad_timeupdate ad_play ad_pause ad_end', function(e)
+$(player).bind( 'apiready play playing canplay canplaythrough loadedmetadata timeupdate progress seeking seeked volumechange durationchange controlschange pause start end video_start video_end ended error fullscreenchange qualitiesavailable qualitychange subtitlesavailable subtitlechange ad_start ad_timeupdate ad_play ad_pause ad_end', function(e)
 {
     var data = {}, player = e.target;
     switch (e.type)
@@ -134,6 +138,10 @@ $(player).bind( 'apiready play playing canplay canplaythrough loadedmetadata tim
         case 'durationchange':
             data['duration'] = player.duration;
             $('#duration').val(timeFormated(player.duration));
+            break;
+
+        case 'controlschange':
+            data['controls'] = player.controls;
             break;
 
         case 'fullscreenchange':


### PR DESCRIPTION
## Features

This pull request adds the following functions & properties:

* `player.setControls(true|false)` Show or hide the controls
* `player.toggleControls()` Toggle the controls
* `player.controls` Get the current controls state (visible / hidden)

## Test case

Compile the player API:

```bash
$ make player_api.js
```

Install a sample video:

```html
<script src="player_api.js"></script>
<div id="player"></div>
<script>
  var player = DM.player(document.getElementById('player'), {
    video: 'xwr14q',
    width: '500px',
    height: '300px',
    params: { autoplay: true }
  });
  player.addEventListener('controlschange', function(evt) {
    console.log('Controls are ' + (player.controls ? 'visible' : 'hidden'));
  })
</script>
```

Test the commands:

```javascript
player.setControls(false) // Should hide the controls and trigger an event
player.toggleControls() // Should show the controls and trigger an event
player.setControls(true) // Nothing should happen
player.controls // Should return true
```