### PR TITLE
[PLAYER] Provide meaningfull warn message for early player API calls

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -203,6 +203,14 @@ DM.provide('Player',
 
     _send: function(command, parameters)
     {
+        if (!this.apiReady) {
+            try {
+                if (console && typeof console.warn === 'function') {
+                    console.warn('Player not ready. Ignoring command : "'+command+'"');
+                }
+            } catch (e) {}
+            return;
+        }
         if (DM.Player.API_MODE == 'postMessage')
         {
             this.contentWindow.postMessage(JSON.stringify({


### PR DESCRIPTION
Calling the player API right after initialization was leading to a browser error about `postMessage`, most likely because the iframe content is not yet available. 
That fix prevents the `postMessage` call to occurs and provides a more meaningful warning in the browser's console.