### PR TITLE
[MAKEFILE] Update yui-compressor binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ FILES := src/third-party/json2.js src/core/prelude.js src/core/json.js src/commo
          src/core/cookie.js src/core/event.js src/core/init.js src/core/epilogue.js src/core/qs.js src/core/api.js \
          src/core/auth.js src/core/player.js
 
-COMPRESSOR_BIN := yuicompressor
+COMPRESSOR_BIN := yui-compressor
 
 TEMP_FILE = /tmp/dailymotion-sdk-js-raw.tmp
 


### PR DESCRIPTION
As we updated all machines with a newer version of Ubuntu, we installed yui-compressor on the provisioning server with the available package.

We need to update the binary name accordingly.

@dharFr Wanna check and merge? Thx.