### PR TITLE
[PLAYER] Handle videochange event. Add video property

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -66,6 +66,7 @@ DM.provide('Player',
     quality: undefined,
     subtitles: [],
     subtitle: undefined,
+    video: null,
 
     play: function() {this.api('play');},
     togglePlay: function() {this.api('toggle-play');},
@@ -275,6 +276,7 @@ DM.provide('Player',
             case 'qualitychange': this.quality = event.quality; break;
             case 'subtitlesavailable': this.subtitles = event.subtitles; break;
             case 'subtitlechange': this.subtitle = event.subtitle; break;
+            case 'videochange': this.video = { videoId: event.videoId, title: event.title}; break;
         }
 
         this._dispatch(event.event);

--- a/tests/player.html
+++ b/tests/player.html
@@ -118,7 +118,7 @@ $('input[type=button]').click(function()
     }
     player.api.apply(player, params);
 });
-$(player).bind( 'apiready play playing canplay canplaythrough loadedmetadata timeupdate progress seeking seeked volumechange durationchange controlschange pause start end video_start video_end ended error fullscreenchange qualitiesavailable qualitychange subtitlesavailable subtitlechange ad_start ad_timeupdate ad_play ad_pause ad_end', function(e)
+$(player).bind( 'apiready play playing canplay canplaythrough loadedmetadata timeupdate progress seeking seeked volumechange durationchange controlschange pause start end video_start video_end ended error fullscreenchange qualitiesavailable qualitychange subtitlesavailable subtitlechange ad_start ad_timeupdate ad_play ad_pause ad_end videochange', function(e)
 {
     var data = {}, player = e.target;
     switch (e.type)
@@ -169,6 +169,9 @@ $(player).bind( 'apiready play playing canplay canplaythrough loadedmetadata tim
             break;
         case 'error':
             data = player.error;
+            break;
+        case 'videochange':
+            data = player.video;
             break;
     }
 


### PR DESCRIPTION
Player API now provides a new `video` property exposing the current `videoId` and `title` of the current video. It will also dispatch a new `videochange` event that will be fired everytime the current video is updated, either at player startup or after a call to `load()` method. This PR updates the SDK to matches those changes.

### Example use :
``` js 
const player = DM.player(div, {video: 'xwr14q'})

// Be notified when the new video has been loaded
player.addEventListener('videochange', () => {
  console.log(player.video.videoId) // -> 'xwr14q'
  console.log(player.video.title)   // -> 'Macklemore & Ryan Lewis - Thrift Shop (feat. Wanz)'
})
player.addEventListener('error', console.error)

// Load a new video
player.load('x5t44n9') 

// videochange handler called a 2nd time. console displays -> 'x5t44n9'+title 
```