### PR TITLE
Parse complex objects with DM.QS.decode()

### DIFF
--- a/src/core/qs.js
+++ b/src/core/qs.js
@@ -65,30 +65,36 @@ DM.provide('QS',
      */
     decode: function(str)
     {
-        var decode = decodeURIComponent,
-            params = {},
-            parts  = str.split('&'),
-            i,
-            pair,
-            key,
-            val;
+        var qsParams = str.split('&');
+        var decode = decodeURIComponent;
 
-        for (i = 0; i < parts.length; i++)
-        {
-            pair = parts[i].split('=', 2);
-            if (pair && pair[0])
-            {
-                key = decode(pair[0]);
-                val = pair[1] ? decode(pair[1].replace(/\+/g, '%20')) : '';
-                if (/\[\]$/.test(key))
-                {
-                    key = key.slice(0,-2);
-                    (params[key] ? params[key] : params[key] = []).push(val);
+        var params = {};
+
+        for(var index = 0; index < qsParams.length; index += 1) {
+            var delimiterIndex = qsParams[index].indexOf('=');
+            if (delimiterIndex < 0 ) {
+                continue;
+            }
+
+            // Get a list of keys and a value from a "depth1[depth2][depth3]=value" string
+            var keyList = decode(qsParams[index].substring(0, delimiterIndex)).replace(/\]/g, '').split('[');
+            var value = decode(qsParams[index].substring(delimiterIndex + 1));
+
+            // Recursively create all the intermediate objects from the keys list,
+            // and set the value when done
+            var destinationParam = params;
+            while (keyList.length > 0) {
+                var keyItem = keyList.shift();
+                if (keyItem.length === 0) {
+                    continue;
                 }
-                else
-                {
-                    params[key] = val;
+                if (keyList.length === 0) {
+                    destinationParam[keyItem] = value;
                 }
+                else if (typeof destinationParam[keyItem] === 'undefined') {
+                    destinationParam[keyItem] = {};
+                }
+                destinationParam = destinationParam[keyItem];
             }
         }
 

--- a/tests/js/qs.js
+++ b/tests/js/qs.js
@@ -32,6 +32,14 @@ test('query string decoding', function()
     ok(multiple.a == 1, 'expect a == 1 in multiple');
     ok(multiple.b == 2, 'expect b == 2 in multiple');
 
+    var complexReference = {
+      depth1a: { depth2: { depth3a: 'value1', depth3b: 'value2[withSpecialChars]&stuff' } },
+      depth1b: { depth2: 'value3' },
+      depth1c: 'value4'
+    }
+    var complex = DM.QS.decode('depth1a%5Bdepth2%5D%5Bdepth3a%5D=value1&depth1a%5Bdepth2%5D%5Bdepth3b%5D=value2%5BwithSpecialChars%5D%26stuff&depth1b%5Bdepth2%5D=value3&depth1c=value4');
+    ok(JSON.stringify(complexReference) === JSON.stringify(complex), 'expect complex object to be valid');
+
     var encoded = DM.QS.decode('a%20b%20c=d%20e%20f');
     ok(encoded['a b c'] == 'd e f', 'expect decoded key and value');
 });


### PR DESCRIPTION
We should be able to parse complex query strings.

Example:

```
DM.QS.decode('depth1a%5Bdepth2%5D%5Bdepth3a%5D=value1&depth1a%5Bdepth2%5D%5Bdepth3b%5D=value2%5BwithSpecialChars%5D%26stuff&depth1b%5Bdepth2%5D=value3&depth1c=value4')
```

Should return:

```javascript
{
  depth1a: {
    depth2: {
      depth3a: 'value1',
      depth3b: 'value2[withSpecialChars]&stuff'
    }
  },
  depth1b: {
    depth2: 'value3'
  },
  depth1c: 'value4'
}
```