### PR TITLE
Support HTTPS embeds on HTTP pages

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -41,6 +41,7 @@ DM.provide('',
  */
 DM.provide('Player',
 {
+    _IFRAME_ORIGIN: null,
     _INSTANCES: {},
     _INTERVAL_ID: null,
     _PROTOCOL: null,
@@ -192,7 +193,11 @@ DM.provide('Player',
 
             var handler = function(e)
             {
-                if (!e.origin || e.origin.indexOf(DM.Player._PROTOCOL + DM._domain.www) !== 0) return;
+                var originDomain = e.origin ? e.origin.replace(/^https?:/, '') : null;
+                if (!originDomain || originDomain.indexOf(DM._domain.www) !== 0) return;
+                if (!DM.Player._IFRAME_ORIGIN) {
+                  DM.Player._IFRAME_ORIGIN = e.origin
+                }
                 var event = DM.QS.decode(e.data);
                 if (!event.id || !event.event) return;
                 var player = DM.$(event.id);
@@ -218,7 +223,7 @@ DM.provide('Player',
             this.contentWindow.postMessage(JSON.stringify({
                 command    : command,
                 parameters : parameters || []
-            }), DM.Player._PROTOCOL + DM._domain.www);
+            }), DM.Player._IFRAME_ORIGIN);
         }
     },
 

--- a/tests/player.html
+++ b/tests/player.html
@@ -69,10 +69,10 @@ Status: <span id="status">unknown</span>
 <script>
 document.getElementById('platform').innerHTML = navigator.platform;
 
-//DM._domain.www = 'http://preprod.dailymotion.com';
-//DM._domain.www = 'http://stage-01.dailymotion.com';
-//DM._domain.www = 'http://local.dailymotion.com';
-// DM._domain.www = 'http://localhost:9090';
+//DM._domain.www = '//preprod.dailymotion.com';
+//DM._domain.www = '//stage-01.dailymotion.com';
+//DM._domain.www = '//local.dailymotion.com';
+// DM._domain.www = '//localhost:9090';
 
 var params = {},
     video = 'xwr14q',


### PR DESCRIPTION
When embedding a player in an `http` page, the iframe may be `https` (because of our HTTPS migration), so we can't assume `embed protocol === embedder protocol` anymore.

Let's fix by dynamically using the embed URL as the `origin` when sending _embedder to embed_ `postMessage` commands.