### PR TITLE
Autoplay feature policy

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -133,6 +133,7 @@ DM.provide('Player',
         });
         player.setAttribute("frameborder", "0");
         player.setAttribute("allowfullscreen", "true");
+        player.setAttribute("allow", "autoplay");
         player.title = "Dailymotion " + options.title;
         player.type = "text/html";
         player.width = options.width;

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -133,8 +133,6 @@ DM.provide('Player',
         });
         player.setAttribute("frameborder", "0");
         player.setAttribute("allowfullscreen", "true");
-        player.setAttribute("webkitallowfullscreen", "true");
-        player.setAttribute("mozallowfullscreen", "true");
         player.title = "Dailymotion " + options.title;
         player.type = "text/html";
         player.width = options.width;


### PR DESCRIPTION
 - Remove deprecated `webkitallowfullscreen` attribute
 - Remove deprecated `mozallowfullscreen` attribute
 - Add `allow="autoplay"` attribute to support 'autoplay' Feature Policy (see [Autoplay Policy Changes](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe))