### PR TITLE
Decode array encoded with bracket in DM.QS.decode

### DIFF
--- a/src/core/qs.js
+++ b/src/core/qs.js
@@ -72,7 +72,7 @@ DM.provide('QS',
 
         for(var index = 0; index < qsParams.length; index += 1) {
             var delimiterIndex = qsParams[index].indexOf('=');
-            if (delimiterIndex < 0 ) {
+            if (delimiterIndex < 1 ) {
                 continue;
             }
 
@@ -85,14 +85,16 @@ DM.provide('QS',
             var destinationParam = params;
             while (keyList.length > 0) {
                 var keyItem = keyList.shift();
-                if (keyItem.length === 0) {
-                    continue;
-                }
                 if (keyList.length === 0) {
-                    destinationParam[keyItem] = value;
+                    if (keyItem.length === 0) {
+                       destinationParam.push(value);
+                    }
+                    else {
+                        destinationParam[keyItem] = value;
+                    }
                 }
                 else if (typeof destinationParam[keyItem] === 'undefined') {
-                    destinationParam[keyItem] = {};
+                    destinationParam[keyItem] = keyList[0].length === 0 ? [] : {};
                 }
                 destinationParam = destinationParam[keyItem];
             }


### PR DESCRIPTION
Dailymotion player is encoding an object like `{ qualities: [720, 480] }` into `'qualities[]=720&qualities[]=480'` but our sdk was not able to decode it properly.

This PR fix it so that the code below works.

```javascript
DM.QS.decode('qualities%5B%5D=720&qualities%5B%5D=480')
// returns
{
  qualities: ['720', '480']
}
```