### PR TITLE
Add playlist parameter

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -142,7 +142,7 @@ DM.provide('Player',
 
         DM.copy(player, DM.Player);
 
-        player.init(options.video, options.params);
+        player.init(options.video, options.params, options.playlist);
 
         if (typeof options.events == "object")
         {
@@ -155,7 +155,18 @@ DM.provide('Player',
         return player;
     },
 
-    init: function(video, params)
+    getPathname: function(video, playlist)
+    {
+        if (playlist) {
+            return "/embed/playlist/" + playlist
+        }
+        if (video) {
+            return "/embed/video/" + video
+        }
+        return "/embed"
+    },
+
+    init: function(video, params, playlist)
     {
         var self = this;
         DM.Player._installHandlers();
@@ -173,7 +184,7 @@ DM.provide('Player',
             params.apiKey = DM._apiKey;
         }
         this.id = params.id = this.id ? this.id : DM.guid();
-        this.src = DM.Player._PROTOCOL + DM._domain.www + "/embed" + (video ? "/video/" + video : "") + '?' + DM.QS.encode(params);
+        this.src = DM.Player._PROTOCOL + DM._domain.www + this.getPathname(video, playlist) + '?' + DM.QS.encode(params);
         if (DM.Player._INSTANCES[this.id] != this)
         {
             DM.Player._INSTANCES[this.id] = this;

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -155,7 +155,7 @@ DM.provide('Player',
         return player;
     },
 
-    getPathname: function(video, playlist)
+    _getPathname: function(video, playlist)
     {
         if (playlist) {
             return "/embed/playlist/" + playlist

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -184,7 +184,7 @@ DM.provide('Player',
             params.apiKey = DM._apiKey;
         }
         this.id = params.id = this.id ? this.id : DM.guid();
-        this.src = DM.Player._PROTOCOL + DM._domain.www + this.getPathname(video, playlist) + '?' + DM.QS.encode(params);
+        this.src = DM.Player._PROTOCOL + DM._domain.www + this._getPathname(video, playlist) + '?' + DM.QS.encode(params);
         if (DM.Player._INSTANCES[this.id] != this)
         {
             DM.Player._INSTANCES[this.id] = this;


### PR DESCRIPTION
The player can now be created in playlist mode by passing a playlist id as shown below.

```js
var player = DM.player(document.getElementById('player'), {
  playlist: 'x5wst3'
});
```

If you pass video id and playlist id like this:
```js
var player = DM.player(document.getElementById('player'), {
  playlist: 'x5wst3',
  video: 'x5wst2'
});
```

The video id is ignored, and playlist id is used. 

