### PR TITLE
Fix a small typo in toggle-muted button in SDK test page

### DIFF
--- a/tests/player.html
+++ b/tests/player.html
@@ -44,7 +44,7 @@ input[type=button]:hover {background: #efefef}
 <input type=button value=subtitle prompt="Subtitle" default=none>
 </div>
 <div>
-<input type=button value=toggle-mute>
+<input type=button value=toggle-muted>
 <input type=button value=mute>
 <input type=button value=unmute>
 <input type=button value=volume prompt="Volume" default=1>


### PR DESCRIPTION
The button Toggle-muted in SDK test page was called Toggle-mute (without 'd') and it was not working