### PR TITLE
PV-9192: [SDK JS] Support playlists in player.load() and DM.create()

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -158,7 +158,7 @@ DM.provide('Player',
 
     _getPathname: function(video, playlist)
     {
-        if (playlist) {
+        if (playlist && !video) {
             return "/embed/playlist/" + playlist
         }
         if (video) {
@@ -184,6 +184,11 @@ DM.provide('Player',
         {
             params.apiKey = DM._apiKey;
         }
+
+        if (video && playlist) {
+            params.playlist = playlist;
+        }
+
         this.id = params.id = this.id ? this.id : DM.guid();
         this.src = DM.Player._PROTOCOL + DM._domain.www + this._getPathname(video, playlist) + '?' + DM.QS.encode(params);
         if (DM.Player._INSTANCES[this.id] != this)


### PR DESCRIPTION
Following new specifications in https://wiki.dailymotion.com/display/PLAYER/Playlist+in+Up+Next+Queue
The decision was made to align the internal API behaviour with the SDK behaviour.
When a player is created with:
```
var player = DM.player(document.getElementById('player'), {
  playlist: 'x5zhzj',
  video: 'x730nnd'
});
```
the video and the playlist will be used in the iframe location: https://www.dailymotion.com/embed/video/x730nnd?playlist=x5zhzj