### PR TITLE
PV-932: Implement a destroy method for the sdk and the inline integration

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -34,7 +34,14 @@ DM.provide('',
 
     destroy: function(id)
     {
-        DM.Player.destroy(id)
+        if (id === undefined) {  // destroy all players of the page
+            Object.keys(DM.Player._INSTANCES).forEach(function(id)
+            {
+                DM.Player.destroy(id)
+            });
+        } else if (DM.Player._INSTANCES[id] !== undefined) {  // destroy a player by its id
+            DM.Player.destroy(id)
+        }
     }
 });
 
@@ -163,13 +170,9 @@ DM.provide('Player',
 
     destroy: function(id)
     {
-        console.log(DM.Player)
-        
-        if (DM.Player._INSTANCES[id] !== undefined) {
-            document.getElementById(id).remove()
-            delete DM.Player._INSTANCES[id];
-            // TODO remove listeners : player.removeEventListener(name, options.events[name], false);
-        }
+        document.getElementById(id).remove()
+        delete DM.Player._INSTANCES[id];
+        // TODO remove listeners : player.removeEventListener(name, options.events[name], false);
     },
 
     _getPathname: function(video, playlist)

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -35,12 +35,11 @@ DM.provide('',
     destroy: function(id)
     {
         if (id === undefined) {  // destroy all players of the page
-            Object.keys(DM.Player._INSTANCES).forEach(function(id)
-            {
-                DM.Player.destroy(id)
-            });
+            for (var key in DM.Player._INSTANCES) {
+                DM.Player.destroy(key);
+            }
         } else if (DM.Player._INSTANCES[id] !== undefined) {  // destroy a player by its id
-            DM.Player.destroy(id)
+            DM.Player.destroy(id);
         }
     }
 });
@@ -174,16 +173,18 @@ DM.provide('Player',
     {
         var player = DM.Player._INSTANCES[id];
         var anchor = DM.Player._ANCHORS[id];
-        
+
         // remove options events listeners
-        DM.Player._EVENTS[id].forEach(function(event)
+        DM.Array.forEach(DM.Player._EVENTS[id], function(event)
         {
-            var name = Object.keys(event)[0]
+            var name = DM.Array.keys(event)[0]
             player.removeEventListener(name, event[name], false);
         });
-        
+
         player.parentNode.replaceChild(anchor, player);  // replace the iframe by its initial anchor
         delete DM.Player._INSTANCES[id];  // remove player instance
+        delete DM.Player._ANCHORS[id];  // remove anchor of player instance
+        delete DM.Player._EVENTS[id];  // remove events of player instance
     },
 
     _getPathname: function(video, playlist)
@@ -226,7 +227,11 @@ DM.provide('Player',
             DM.Player._INSTANCES[this.id] = this;
             DM.Player._EVENTS[this.id] = events;
             DM.Player._ANCHORS[this.id] = element;
-            this.addEventListener('unload', function() {delete DM.Player._INSTANCES[this.id];});
+            this.addEventListener('unload', function() {
+                delete DM.Player._INSTANCES[this.id];
+                delete DM.Player._ANCHORS[this.id];
+                delete DM.Player._EVENTS[this.id];
+            });
         }
 
         this.autoplay = DM.parseBool(params.autoplay);
@@ -239,6 +244,7 @@ DM.provide('Player',
         {
             DM.Player.API_MODE = "postMessage";
 
+            console.log('Handler is always OK when you Destroy/Create but KO when you Play via button/Destroy/Re-create')
             var handler = function(e)
             {
                 var originDomain = e.origin ? e.origin.replace(/^https?:/, '') : null;
@@ -247,6 +253,7 @@ DM.provide('Player',
                   DM.Player._IFRAME_ORIGIN = e.origin
                 }
                 var event = DM.Player._decodePostMessage(e.data);
+                console.log('handler', event.event)
                 if (!event.id || !event.event) return;
                 var player = DM.$(event.id);
                 player._recvEvent(event);

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -29,16 +29,30 @@ DM.provide('',
 {
     player: function(element, options)
     {
+        element = DM.$(element);
+        if (DM.Player._INSTANCES[element.id] !== undefined)
+            throw new Error("Invalid first argument sent to DM.destroy(), this element is already a player: " + element.id);
+        if (!element || element.nodeType !== Node.ELEMENT_NODE)
+            throw new Error("Invalid first argument sent to DM.player(), requires a HTML element or element id: " + element.id);
+        if (!options || typeof options !== 'object')
+            throw new Error("Missing `options' parameter for DM.player()");
+
         return DM.Player.create(element, options);
     },
 
     destroy: function(id)
     {
-        if (id === undefined) {  // destroy all players of the page
+        if (!id) {  // destroy all players of the page
+            if (DM.Array.keys(DM.Player._INSTANCES).length === 0)
+                throw new Error("DM.destroy(): no player to destroy");
+
             for (var key in DM.Player._INSTANCES) {
                 DM.Player.destroy(key);
             }
-        } else if (DM.Player._INSTANCES[id] !== undefined) {  // destroy a player by its id
+        } else {  // destroy a single player
+            if (DM.Player._INSTANCES[id] === undefined)
+                throw new Error("Invalid first argument sent to DM.destroy(), requires a player id: " + id);
+
             DM.Player.destroy(id);
         }
     }
@@ -108,12 +122,6 @@ DM.provide('Player',
 
     create: function(element, options)
     {
-        element = DM.$(element);
-        if (!element || element.nodeType != 1)
-            throw new Error("Invalid first argument sent to DM.player(), requires a HTML element or element id: " + element);
-        if (!options || typeof options != 'object')
-            throw new Error("Missing `options' parameter for DM.player()");
-
         options = DM.copy(options,
         {
             width: 480,
@@ -177,7 +185,7 @@ DM.provide('Player',
         // remove options events listeners
         DM.Array.forEach(DM.Player._EVENTS[id], function(event)
         {
-            var name = DM.Array.keys(event)[0]
+            var name = DM.Array.keys(event)[0];
             player.removeEventListener(name, event[name], false);
         });
 

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -262,7 +262,7 @@ DM.provide('Player',
                 var event = DM.Player._decodePostMessage(e.data);
                 if (!event.id || !event.event) return;
                 var player = DM.$(event.id);
-                if (!player) return;
+                if (!player || typeof player._recvEvent !== 'function') return;
                 player._recvEvent(event);
             };
             if (window.addEventListener) window.addEventListener("message", handler, false);

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -30,12 +30,12 @@ DM.provide('',
     player: function(element, options)
     {
         element = DM.$(element);
-        if (DM.Player._INSTANCES[element.id] !== undefined)
-            throw new Error("Invalid first argument sent to DM.destroy(), this element is already a player: " + element.id);
         if (!element || element.nodeType !== Node.ELEMENT_NODE)
-            throw new Error("Invalid first argument sent to DM.player(), requires a HTML element or element id: " + element.id);
+            throw new Error("Invalid first argument sent to DM.player(), requires a HTML element or element id: " + element);
+        if (element.nodeName === 'IFRAME' || DM.Player._INSTANCES[element.id] !== undefined)
+            throw new Error("Invalid first argument sent to DM.player(), this element is already a player: " + element.id);
         if (!options || typeof options !== 'object')
-            throw new Error("Missing `options' parameter for DM.player()");
+            throw new Error("Missing 'options' parameter for DM.player()");
 
         return DM.Player.create(element, options);
     },
@@ -286,16 +286,14 @@ DM.provide('Player',
 
     _send: function(command, parameters)
     {
-        if (!this.apiReady) {
-            try {
-                if (console && typeof console.warn === 'function') {
-                    console.warn('Player not ready. Ignoring command : "'+command+'"');
-                }
-            } catch (e) {}
-            return;
-        }
+        if (!this.apiReady)
+            throw new Error('Player not ready. Ignoring command : "'+command+'"');
+
         if (DM.Player.API_MODE == 'postMessage')
         {
+            if (!this.contentWindow || typeof this.contentWindow.postMessage !== 'function')
+                throw new Error('Player not reachable anymore. You may have destroyed it.');
+
             this.contentWindow.postMessage(JSON.stringify({
                 command    : command,
                 parameters : parameters || []

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -30,6 +30,11 @@ DM.provide('',
     player: function(element, options)
     {
         return DM.Player.create(element, options);
+    },
+
+    destroy: function(id)
+    {
+        DM.Player.destroy(id)
     }
 });
 
@@ -154,6 +159,17 @@ DM.provide('Player',
         }
 
         return player;
+    },
+
+    destroy: function(id)
+    {
+        console.log(DM.Player)
+        
+        if (DM.Player._INSTANCES[id] !== undefined) {
+            document.getElementById(id).remove()
+            delete DM.Player._INSTANCES[id];
+            // TODO remove listeners : player.removeEventListener(name, options.events[name], false);
+        }
     },
 
     _getPathname: function(video, playlist)

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -244,18 +244,17 @@ DM.provide('Player',
         {
             DM.Player.API_MODE = "postMessage";
 
-            console.log('Handler is always OK when you Destroy/Create but KO when you Play via button/Destroy/Re-create')
             var handler = function(e)
             {
                 var originDomain = e.origin ? e.origin.replace(/^https?:/, '') : null;
                 if (!originDomain || originDomain.indexOf(DM._domain.www) !== 0) return;
                 if (!DM.Player._IFRAME_ORIGIN) {
-                  DM.Player._IFRAME_ORIGIN = e.origin
+                  DM.Player._IFRAME_ORIGIN = e.origin;
                 }
                 var event = DM.Player._decodePostMessage(e.data);
-                console.log('handler', event.event)
                 if (!event.id || !event.event) return;
                 var player = DM.$(event.id);
+                if (!player) return;
                 player._recvEvent(event);
             };
             if (window.addEventListener) window.addEventListener("message", handler, false);

--- a/tests/player.html
+++ b/tests/player.html
@@ -91,7 +91,7 @@ document.getElementById('platform').innerHTML = navigator.platform;
 //DM._domain.www = '//preprod.dailymotion.com';
 //DM._domain.www = '//stage-01.dailymotion.com';
 //DM._domain.www = '//local.dailymotion.com';
-// DM._domain.www = '//localhost:9090';
+//DM._domain.www = '//localhost:9090';
 
 let params = {};
 const video = 'x730nnd';
@@ -107,6 +107,10 @@ const playerbis = DM.player(document.getElementById('playerbis'), {
     params,
     width: '10%',
     height: '10%',
+    events: [
+        { 'play': function() { console.log('play'); }},
+        { 'pause': function() { console.log('pause'); }},
+    ]
 });
 
 

--- a/tests/player.html
+++ b/tests/player.html
@@ -26,8 +26,12 @@
         input[type=button]:hover, button:hover {
             background: #efefef
         }
-        #player {
+        #player1 {
             height: 350px;
+            width: 100%
+        }
+        #player2, #player3 {
+            height: 25px;
             width: 100%
         }
         #progress, #duration {
@@ -89,10 +93,14 @@
     <script src="../src/core/auth.js"></script>
 </head>
 <body>
-    <div id="player"></div>
+    <div id="player1"></div>
+    <div id="player2"></div>
+    <div id="player3"></div>
+    
     <div id="controls">
         <div>
-            <button id="create-player">Create Player</button> / <button id="destroy-player">Destroy Player</button>
+            <input type=button value=create prompt="ID" default=player2>
+            <input type=button value=destroy prompt="ID" default=player1>
         </div>
         <div>
             <input type=button value=toggle-play>
@@ -145,8 +153,8 @@
         const statusEl = document.getElementById('status');
         let player;
 
-        function createPlayer() {
-            player = DM.player(document.getElementById('player'), {
+        function createPlayer(id) {
+            player = DM.player(document.getElementById(id), {
                 video,
                 params: {},
                 width: '100%',
@@ -184,18 +192,14 @@
                 if (cmd === 'load' && !autoplayEl.checked) {
                     params.push({ autoplay: false });
                 }
-                player.api.apply(player, params);
-            }
-        }
-
-        function handleButton(e) {
-            const id = e.target.id;
-            if (player && id === 'destroy-player') {
-                DM.destroy('player');
-                player = null;
-            }
-            if (!player && id === 'create-player') {
-                createPlayer();
+                if (cmd === 'destroy') {
+                    DM.destroy(arg);
+                }
+                else if (cmd === 'create') {
+                    createPlayer(arg);
+                } else {
+                    player.api.apply(player, params);
+                }
             }
         }
 
@@ -279,7 +283,7 @@
             }
         }
 
-        createPlayer();
+        createPlayer('player1');
 
         document.querySelector('input[name=html]').addEventListener('change', function(e){
             const params = {};
@@ -307,9 +311,6 @@
 
         document.querySelectorAll('input[type=button]').forEach(input => {
             input.addEventListener('click', handleClick);
-        });
-        document.querySelectorAll('button').forEach(button => {
-            button.addEventListener('click', handleButton);
         });
     </script>
 </body>

--- a/tests/player.html
+++ b/tests/player.html
@@ -1,258 +1,313 @@
 <!DOCTYPE html>
-<script src="../src/third-party/json2.js"></script>
-<script src="../src/core/prelude.js"></script>
-<script src="../src/common/array.js"></script>
-<script src="../src/core/qs.js"></script>
-<script src="../src/core/player.js"></script>
+<head>
+    <style>
+        * {
+            font-family: sans-serif
+        }
+        body {
+            margin: 0;
+            overflow: hidden;
+            width: 100%;
+            height: 100%;
+            position: absolute;
+        }
+        input, button {
+            font-size: 20px;
+            border: 1px solid #333;
+            background: #fff;
+            margin-left: 0
+        }
+        input[type=button], button {
+            cursor: pointer;
+        }
+        button {
+            margin-bottom: 20px;
+        }
+        input[type=button]:hover, button:hover {
+            background: #efefef
+        }
+        #player {
+            height: 350px;
+            width: 100%
+        }
+        #progress, #duration {
+            width: 80px;
+            text-align:center
+        }
+        #console {
+            height: 100%;
+            width: 100%;
+            margin: 0;
+            overflow: auto;
+            list-style-type: none;
+            padding: 5px;
+            background: #eee;
+            box-sizing: border-box;
+        }
+        #console li {
+            padding: 2px;
+            font-family: courier;
+            font-size: 18px
+        }
+        .in {
+            color: #232295
+        }
+        .out {
+            color: #d05c00
+        }
+        .minor {
+            color: #ccc
+        }
+        .info {
+            color: #00a3bc
+        }
+        .fatal {
+            color: #ff3333
+        }
+        #console.hide-minor .minor {
+            display: none
+        }
+        #controls div {
+            margin: 5px
+        }
+        .float-right {
+            float: right;
+            margin-right: 10px;
+        }
+    </style>
 
-<script src="../src/core/json.js"></script>
-<script src="../src/core/cookie.js"></script>
-<script src="../src/core/event.js"></script>
-<script src="../src/core/init.js"></script>
-<script src="../src/core/api.js"></script>
-<script src="../src/core/auth.js"></script>
+    <script src="../src/third-party/json2.js"></script>
+    <script src="../src/core/prelude.js"></script>
+    <script src="../src/common/array.js"></script>
+    <script src="../src/core/qs.js"></script>
+    <script src="../src/core/player.js"></script>
+    <script src="../src/core/json.js"></script>
+    <script src="../src/core/cookie.js"></script>
+    <script src="../src/core/event.js"></script>
+    <script src="../src/core/init.js"></script>
+    <script src="../src/core/api.js"></script>
+    <script src="../src/core/auth.js"></script>
+</head>
+<body>
+    <div id="player"></div>
+    <div id="controls">
+        <div>
+            <button id="create-player">Create Player</button> / <button id="destroy-player">Destroy Player</button>
+        </div>
+        <div>
+            <input type=button value=toggle-play>
+            <input type=button value=play>
+            <input type=button value=pause>
+            <input type=button value=load prompt="Video Id" default=x2m8jpp>
+            <input type=button value=fullscreen>
+            <input type=button value=watch-on-site>
+            <span class="float-right">Platform: <span id="platform"></span></span>
+        </div>
+        <div>
+            <input type=button value=quality prompt="Quality" default=240>
+            <input type=button value=subtitle prompt="Subtitle" default=none>
+        </div>
+        <div>
+            <input type=button value=toggle-muted>
+            <input type=button value=mute>
+            <input type=button value=unmute>
+            <input type=button value=volume prompt="Volume" default=1>
+        </div>
+        <div>
+            <input type=button value=toggle-controls>
+            <input type=button value="controls" prompt="Controls" default=1>
+        </div>
+        <div>
+            <input id="progress" value="--:--">
+            <input id="duration" value="--:--">
+            Status: <span id="status">unknown</span>
+            <span class="float-right"><input type=checkbox name=empty> Force Empty Player</span>
+            <span class="float-right"><input type=checkbox name=html> Force HTML</span>
+            <span class="float-right"><input type=checkbox name=autoplay checked> Autoplay on load</span>
+        </div>
+    </div>
+    <ul id="console" class="hide-minor"></ul>
+    <span style="position: absolute; bottom: 10px; right: 10px">
+        <input type=checkbox name=hide checked> Hide time updates
+    </span>
+    <script>
+        document.getElementById('platform').innerHTML = navigator.platform;
+        //DM._domain.www = '//preprod.dailymotion.com';
+        // DM._domain.www = '//stage-01.dailymotion.com';
+        //DM._domain.www = '//local.dailymotion.com';
+        // DM._domain.www = '//localhost:9090';
+        const events = ['apiready', 'play', 'playback_ready', 'playing', 'canplay', 'canplaythrough', 'loadedmetadata', 'timeupdate', 'progress', 'seeking', 'seeked', 'volumechange', 'durationchange', 'controlschange', 'pause', 'start', 'end', 'video_start', 'video_end', 'ended', 'error', 'fullscreenchange', 'qualitiesavailable', 'qualitychange', 'subtitlesavailable', 'subtitlechange', 'ad_start', 'ad_timeupdate', 'ad_play', 'ad_pause', 'ad_end', 'videochange', 'ad_companions'];
+        const video = 'x730nnd';
+        const consoleEl = document.getElementById('console');
+        const autoplayEl = document.querySelector('input[name=autoplay]');
+        const progressEl = document.getElementById('progress');
+        const durationEl = document.getElementById('duration');
+        const statusEl = document.getElementById('status');
+        let params = {};
+        let player;
 
-<style>
-* {font-family: sans-serif}
-body {
-    margin: 0;
-    overflow: hidden;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-}
-input {font-size: 20px; border: 1px solid #333; background: #fff; margin-left: 0}
-input[type=button] { cursor: pointer; }
-input[type=button]:hover {background: #efefef}
-#player {height: 350px; width: 100%}
-#progress, #duration {width: 80px; text-align:center}
-#console {
-    height: 100%;
-    width: 100%;
-    margin: 0;
-    overflow: auto;
-    list-style-type: none;
-    padding: 5px;
-    background: #eee;
-    box-sizing: border-box;
-}
-#console li {padding: 2px; font-family: courier; font-size: 18px}
-.in {color: #232295} .out {color: #d05c00} .minor {color: #ccc} .info {color: #00a3bc} .fatal {color: #ff3333}
-#console.hide-minor .minor {display: none}
-#controls div {margin: 5px}
-.float-right { float: right; margin-right: 10px; }
-</style>
+        function createPlayer() {
+            player = DM.player(document.getElementById('player'), {
+                video,
+                params,
+                width: '100%',
+                height: '100%',
+                events: {
+                    play: function() { console.log('play'); },
+                    pause: function() { console.log('pause'); }
+                }
+            });
+            events.forEach(event => player.addEventListener(event, handlePlayerEvents));
+        }
 
-<div id="player"></div>
-<div id="playerbis"></div>
-<div id="controls">
-<div>
-<input type=button value=toggle-play>
-<input type=button value=play>
-<input type=button value=pause>
-<input type=button value=load prompt="Video Id" default=x2m8jpp>
-<input type=button value=fullscreen>
-<input type=button value=watch-on-site>
-<span class="float-right">Platform: <span id="platform"></span></span>
-</div>
-<div>
-<input type=button value=quality prompt="Quality" default=240>
-<input type=button value=subtitle prompt="Subtitle" default=none>
-</div>
-<div>
-<input type=button value=toggle-muted>
-<input type=button value=mute>
-<input type=button value=unmute>
-<input type=button value=volume prompt="Volume" default=1>
-</div>
-<div>
-<input type=button value=toggle-controls>
-<input type=button value="controls" prompt="Controls" default=1>
-</div>
-<div>
-<input type=button value="destroy" prompt="Player Id" default=playerbis>
-</div>
-<div>
-<input id="progress" value="--:--">
-<input id="duration" value="--:--">
-Status: <span id="status">unknown</span>
-<span class="float-right"><input type=checkbox name=empty> Force Empty Player</span>
-<span class="float-right"><input type=checkbox name=html> Force HTML</span>
-<span class="float-right"><input type=checkbox name=autoplay checked> Autoplay on load</span>
-</div>
-</div>
+        function logToConsole(className, text) {
+            const log = document.createElement('li')
+            log.className = className;
+            log.innerHTML = text;
+            consoleEl.insertBefore(log, consoleEl.firstChild);
+        }
 
-<ul id="console" class="hide-minor"></ul>
-<span style="position: absolute; bottom: 10px; right: 10px"><input type=checkbox name=hide checked> Hide time updates</span>
+        function handleClick(e) {
+            if (player) {
+                const cmd = e.target.value;
+                let arg;
+                const message = e.target.getAttribute('prompt');
+                const defaultVal = e.target.getAttribute('default');
+                if (message) {
+                    arg = prompt(message, defaultVal);
+                    if(arg === null) return;
+                }
 
-<script>
-document.getElementById('platform').innerHTML = navigator.platform;
+                logToConsole('out', `&lt;- ${cmd}${arg ? '=' + arg : ''}`);
 
-//DM._domain.www = '//preprod.dailymotion.com';
-//DM._domain.www = '//stage-01.dailymotion.com';
-//DM._domain.www = '//local.dailymotion.com';
-//DM._domain.www = '//localhost:9090';
+                params = arg ? [cmd, arg] : [cmd];
+                if (cmd === 'load' && !autoplayEl.checked) {
+                    params.push({ autoplay: false });
+                }
+                player.api.apply(player, params);
+            }
+        }
 
-let params = {};
-const video = 'x730nnd';
-const player = DM.player(document.getElementById('player'), {
-    video,
-    params,
-    width: '100%',
-    height: '100%',
-});
+        function handleButton(e) {
+            const id = e.target.id;
+            if (player && id === 'destroy-player') {
+                DM.destroy('player');
+                player = null;
+            }
+            if (!player && id === 'create-player') {
+                createPlayer();
+            }
+        }
 
-const playerbis = DM.player(document.getElementById('playerbis'), {
-    video,
-    params,
-    width: '10%',
-    height: '10%',
-    events: [
-        { 'play': function() { console.log('play'); }},
-        { 'pause': function() { console.log('pause'); }},
-    ]
-});
+        function timeFormated(seconds) {
+            if (isNaN(seconds) || !isFinite(seconds)) return '--:--';
+            seconds = Math.round(seconds);
+            var hour = (hour = Math.floor(seconds / 3600)) < 10 ? '0' + hour : hour,
+                min = (min = Math.floor(seconds / 60) % 60) < 10 ? '0' + min : min,
+                sec = (sec = seconds % 60) < 10 ? '0' + sec : sec;
 
+            return seconds < 3600 ? min + ':' + sec : hour + 'h' + min;
+        }
 
-const consoleEl = document.getElementById("console");
-const autoplayEl = document.querySelector('input[name=autoplay]');
-const progressEl = document.getElementById('progress');
-const durationEl = document.getElementById('duration');
-const statusEl = document.getElementById('status');
+        function handlePlayerEvents(e) {
+            if (player) {
+                let data = {};
+                switch (e.type) {
+                    case 'timeupdate':
+                    case 'ad_timeupdate':
+                    case 'seeking':
+                    case 'seeked':
+                        data['time'] = player.currentTime;
+                        progressEl.value = timeFormated(player.currentTime);
+                        break;
+                    case 'progress':
+                        data['buffer'] = player.bufferedTime;
+                        break;
+                    case 'durationchange':
+                        data['duration'] = player.duration;
+                        durationEl.value = timeFormated(player.duration);
+                        break;
+                    case 'controlschange':
+                        data['controls'] = player.controls;
+                        break;
+                    case 'fullscreenchange':
+                        data['fullscreen'] = player.fullscreen;
+                        break;
+                    case 'volumechange':
+                        data['volume'] = player.volume;
+                        data['muted'] = player.muted;
+                        break;
+                    case 'qualitiesavailable':
+                        data['qualities'] = player.qualities;
+                        break;
+                    case 'qualitychange':
+                        data['quality'] = player.quality;
+                        break;
+                    case 'subtitlesavailable':
+                        data['subtitles'] = player.subtitles;
+                        break;
+                    case 'subtitlechange':
+                        data['subtitle'] = player.subtitle;
+                        break;
+                    case 'ended':
+                        data['deprecated'] = "Use 'video_end' instead";
+                        break;
+                    case 'error':
+                        data = player.error;
+                        break;
+                    case 'videochange':
+                        data = player.video;
+                        break;
+                    case 'ad_companions':
+                        data = player.companionAds;
+                        break;
+                }
 
-function logToConsole(className, text) {
-    const log = document.createElement('li')
-    log.className = className;
-    log.innerHTML = text;
-    consoleEl.insertBefore(log, consoleEl.firstChild);
-}
+                if (['play', 'playing', 'pause', 'ad_play', 'ad_pause'].includes(e.type)) {
+                    statusEl.innerHTML = e.type;
+                }
 
-document.querySelector('input[name=html]').addEventListener("change", function(e){
-    params.html = e.target.checked ? "1" : "0";
-    player.init(video, params);
-    logToConsole('info', `** html= ${params.html}`);
-});
+                const classNames = ['in'];
+                if (['timeupdate', 'progress', 'ad_timeupdate'].includes(e.type)) {
+                    classNames.push('minor');
+                }
+                if (e.type == 'error') {
+                    classNames.push('fatal');
+                }
 
-document.querySelector('input[name=empty]').addEventListener("change", function(e){
-    const v = e.target.checked ? undefined : video;
-    player.init(v, params);
-    logToConsole('info', `** empty player: ${!v ? 'on' : 'off'}`);
-});
+                logToConsole(classNames.join(' '), `-&gt; ${e.type} ${JSON.stringify(data)}`);
+            }
+        }
 
-document.querySelector('input[name=hide]').addEventListener('change', function(e) {
-    e.target.checked
-        ? consoleEl.classList.add('hide-minor')
-        : consoleEl.classList.remove('hide-minor');
-});
+        createPlayer();
 
-function handleClick(e) {
-    const cmd = e.target.value;
-    let arg;
-    const message = e.target.getAttribute('prompt');
-    const defaultVal = e.target.getAttribute('default');
-    if (message) {
-        arg = prompt(message, defaultVal);
-        if(arg === null) return;
-    }
+        document.querySelector('input[name=html]').addEventListener('change', function(e){
+            if (player) {
+                params.html = e.target.checked ? '1' : '0';
+                player.init(video, params);
+                logToConsole('info', `** html= ${params.html}`);
+            }
+        });
 
-    logToConsole('out', `&lt;- ${cmd}${arg ? '=' + arg : ''}`);
+        document.querySelector('input[name=empty]').addEventListener('change', function(e){
+            if (player) {
+                const v = e.target.checked ? undefined : video;
+                player.init(v, params);
+                logToConsole('info', `** empty player: ${!v ? 'on' : 'off'}`);
+            }
+        });
 
-    params = arg ? [cmd, arg] : [cmd];
-    if (cmd === 'load' && !autoplayEl.checked) {
-        params.push({ autoplay: false });
-    }
+        document.querySelector('input[name=hide]').addEventListener('change', function(e) {
+            e.target.checked
+                ? consoleEl.classList.add('hide-minor')
+                : consoleEl.classList.remove('hide-minor');
+        });
 
-    if (cmd === 'destroy') {
-        DM.destroy(params[1]);
-    } else {
-        player.api.apply(player, params);
-    }
-}
-
-document.querySelectorAll('input[type=button]').forEach(input => {
-    input.addEventListener('click', handleClick);
-})
-
-function timeFormated(seconds) {
-    if (isNaN(seconds) || !isFinite(seconds)) return '--:--';
-    seconds = Math.round(seconds);
-    var hour = (hour = Math.floor(seconds / 3600)) < 10 ? '0' + hour : hour,
-        min = (min = Math.floor(seconds / 60) % 60) < 10 ? '0' + min : min,
-        sec = (sec = seconds % 60) < 10 ? '0' + sec : sec;
-
-    return seconds < 3600 ? min + ':' + sec : hour + 'h' + min;
-}
-
-const events = ["apiready", "play", "playback_ready", "playing", "canplay", "canplaythrough", "loadedmetadata", "timeupdate", "progress", "seeking", "seeked", "volumechange", "durationchange", "controlschange", "pause", "start", "end", "video_start", "video_end", "ended", "error", "fullscreenchange", "qualitiesavailable", "qualitychange", "subtitlesavailable", "subtitlechange", "ad_start", "ad_timeupdate", "ad_play", "ad_pause", "ad_end", "videochange", "ad_companions"];
-
-function handlePlayerEvents(e) {
-    let data = {};
-    switch (e.type) {
-        case 'timeupdate':
-        case 'ad_timeupdate':
-        case 'seeking':
-        case 'seeked':
-            data['time'] = player.currentTime;
-            progressEl.value = timeFormated(player.currentTime);
-            break;
-        case 'progress':
-            data['buffer'] = player.bufferedTime;
-            break;
-        case 'durationchange':
-            data['duration'] = player.duration;
-            durationEl.value = timeFormated(player.duration);
-            break;
-        case 'controlschange':
-            data['controls'] = player.controls;
-            break;
-        case 'fullscreenchange':
-            data['fullscreen'] = player.fullscreen;
-            break;
-        case 'volumechange':
-            data['volume'] = player.volume;
-            data['muted'] = player.muted;
-            break;
-        case 'qualitiesavailable':
-            data['qualities'] = player.qualities;
-            break;
-        case 'qualitychange':
-            data['quality'] = player.quality;
-            break;
-        case 'subtitlesavailable':
-            data['subtitles'] = player.subtitles;
-            break;
-        case 'subtitlechange':
-            data['subtitle'] = player.subtitle;
-            break;
-        case 'ended':
-            data['deprecated'] = "Use 'video_end' instead";
-            break;
-        case 'error':
-            data = player.error;
-            break;
-        case 'videochange':
-            data = player.video;
-            break;
-        case 'ad_companions':
-            data = player.companionAds;
-            break;
-    }
-
-    if (['play', 'playing', 'pause', 'ad_play', 'ad_pause'].includes(e.type)) {
-        statusEl.innerHTML = e.type;
-    }
-
-    const classNames = ["in"];
-    if (['timeupdate', 'progress', 'ad_timeupdate'].includes(e.type)) {
-        classNames.push('minor');
-    }
-    if (e.type == 'error') {
-        classNames.push('fatal');
-    }
-
-    logToConsole(classNames.join(" "), `-&gt; ${e.type} ${JSON.stringify(data)}`);
-}
-
-events.forEach(event => player.addEventListener(event, handlePlayerEvents));
-
-</script>
+        document.querySelectorAll('input[type=button]').forEach(input => {
+            input.addEventListener('click', handleClick);
+        });
+        document.querySelectorAll('button').forEach(button => {
+            button.addEventListener('click', handleButton);
+        });
+    </script>
+</body>

--- a/tests/player.html
+++ b/tests/player.html
@@ -143,13 +143,12 @@
         const progressEl = document.getElementById('progress');
         const durationEl = document.getElementById('duration');
         const statusEl = document.getElementById('status');
-        let params = {};
         let player;
 
         function createPlayer() {
             player = DM.player(document.getElementById('player'), {
                 video,
-                params,
+                params: {},
                 width: '100%',
                 height: '100%',
                 events: {
@@ -171,6 +170,7 @@
             if (player) {
                 const cmd = e.target.value;
                 let arg;
+                let params;
                 const message = e.target.getAttribute('prompt');
                 const defaultVal = e.target.getAttribute('default');
                 if (message) {
@@ -282,6 +282,7 @@
         createPlayer();
 
         document.querySelector('input[name=html]').addEventListener('change', function(e){
+            const params = {};
             if (player) {
                 params.html = e.target.checked ? '1' : '0';
                 player.init(video, params);
@@ -290,6 +291,7 @@
         });
 
         document.querySelector('input[name=empty]').addEventListener('change', function(e){
+            const params = {};
             if (player) {
                 const v = e.target.checked ? undefined : video;
                 player.init(v, params);

--- a/tests/player.html
+++ b/tests/player.html
@@ -22,6 +22,7 @@ body {
     position: absolute;
 }
 input {font-size: 20px; border: 1px solid #333; background: #fff; margin-left: 0}
+input[type=button] { cursor: pointer; }
 input[type=button]:hover {background: #efefef}
 #player {height: 350px; width: 100%}
 #progress, #duration {width: 80px; text-align:center}
@@ -43,6 +44,7 @@ input[type=button]:hover {background: #efefef}
 </style>
 
 <div id="player"></div>
+<div id="playerbis"></div>
 <div id="controls">
 <div>
 <input type=button value=toggle-play>
@@ -66,6 +68,9 @@ input[type=button]:hover {background: #efefef}
 <div>
 <input type=button value=toggle-controls>
 <input type=button value="controls" prompt="Controls" default=1>
+</div>
+<div>
+<input type=button value="destroy" prompt="Player Id" default=playerbis>
 </div>
 <div>
 <input id="progress" value="--:--">
@@ -96,6 +101,15 @@ const player = DM.player(document.getElementById('player'), {
     width: '100%',
     height: '100%',
 });
+
+const playerbis = DM.player(document.getElementById('playerbis'), {
+    video,
+    params,
+    width: '10%',
+    height: '10%',
+});
+
+
 const consoleEl = document.getElementById("console");
 const autoplayEl = document.querySelector('input[name=autoplay]');
 const progressEl = document.getElementById('progress');
@@ -143,7 +157,12 @@ function handleClick(e) {
     if (cmd === 'load' && !autoplayEl.checked) {
         params.push({ autoplay: false });
     }
-    player.api.apply(player, params)
+
+    if (cmd === 'destroy') {
+        DM.destroy(params[1]);
+    } else {
+        player.api.apply(player, params);
+    }
 }
 
 document.querySelectorAll('input[type=button]').forEach(input => {

--- a/tests/player.html
+++ b/tests/player.html
@@ -26,12 +26,7 @@
         input[type=button]:hover, button:hover {
             background: #efefef
         }
-        #player1 {
-            height: 350px;
-            width: 100%
-        }
-        #player2, #player3 {
-            height: 25px;
+        #player1, #player2, #player3 {
             width: 100%
         }
         #progress, #duration {
@@ -96,7 +91,7 @@
     <div id="player1"></div>
     <div id="player2"></div>
     <div id="player3"></div>
-    
+
     <div id="controls">
         <div>
             <input type=button value=create prompt="ID" default=player2>
@@ -157,8 +152,6 @@
             player = DM.player(document.getElementById(id), {
                 video,
                 params: {},
-                width: '100%',
-                height: '100%',
                 events: {
                     play: function() { console.log('play'); },
                     pause: function() { console.log('pause'); }


### PR DESCRIPTION
## [<img src="http://svgshare.com/i/Gd.svg" height="16px"> PV-932](https://jira.dailymotion.com/browse/PV-932)

Just launch `tests/player.html` in your browser & play with Create / Destroy / Command buttons to drive the Player

- When you Create the Player, `<iframe>` will appear in place of the `<div id="player">`
- When you Destroy, `<div id="player">` will be back and `<iframe>` will be deleted (& everything related to it)

### Steps
- [x] remove the iframe (+ any other inserted HTML elements from DOM) iframe is replaced by its initial anchor
- [x] remove every reference to the player iframe
- [x] remove all event handlers (from the SDK stand-point)
- [x] enrich test page
- [x] Make sure that we can still use the SDK to create/play with another Player

![cool](https://i.giphy.com/media/Vmunw0k7q12Ks/giphy.webp)