### PR TITLE
PV-10264: replace breaking throw by console.warn

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -41,15 +41,27 @@ DM.provide('',
     destroy: function(id)
     {
         if (!id) {  // destroy all players of the page
-            if (DM.Array.keys(DM.Player._INSTANCES).length === 0)
-                throw new Error("DM.destroy(): no player to destroy");
+            if (DM.Array.keys(DM.Player._INSTANCES).length === 0) {
+                try {
+                    if (console && typeof console.warn === 'function') {
+                        console.warn("DM.destroy(): no player to destroy");
+                    }
+                } catch (e) {}
+                return;
+            }
 
             for (var key in DM.Player._INSTANCES) {
                 DM.Player.destroy(key);
             }
         } else {  // destroy a single player
-            if (DM.Player._INSTANCES[id] === undefined)
-                throw new Error("Invalid first argument sent to DM.destroy(), requires a player id: " + id);
+            if (DM.Player._INSTANCES[id] === undefined) {
+                try {
+                    if (console && typeof console.warn === 'function') {
+                        console.warn("Invalid first argument sent to DM.destroy(), requires a player id: " + id);
+                    }
+                } catch (e) {}
+                return;
+            }
 
             DM.Player.destroy(id);
         }
@@ -284,13 +296,25 @@ DM.provide('Player',
 
     _send: function(command, parameters)
     {
-        if (!this.apiReady)
-            throw new Error('Player not ready. Ignoring command : "'+command+'"');
+        if (!this.apiReady) {
+            try {
+                if (console && typeof console.warn === 'function') {
+                    console.warn('Player not ready. Ignoring command : "'+command+'"');
+                }
+            } catch (e) {}
+            return;
+        }
 
         if (DM.Player.API_MODE == 'postMessage')
         {
-            if (!this.contentWindow || typeof this.contentWindow.postMessage !== 'function')
-                throw new Error('Player not reachable anymore. You may have destroyed it.');
+            if (!this.contentWindow || typeof this.contentWindow.postMessage !== 'function') {
+                try {
+                    if (console && typeof console.warn === 'function') {
+                        console.warn('Player not reachable anymore. You may have destroyed it.');
+                    }
+                } catch (e) {}
+                return;
+            }
 
             this.contentWindow.postMessage(JSON.stringify({
                 command    : command,

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -42,11 +42,7 @@ DM.provide('',
     {
         if (!id) {  // destroy all players of the page
             if (DM.Array.keys(DM.Player._INSTANCES).length === 0) {
-                try {
-                    if (console && typeof console.warn === 'function') {
-                        console.warn("DM.destroy(): no player to destroy");
-                    }
-                } catch (e) {}
+                DM.warn("DM.destroy(): no player to destroy");
                 return;
             }
 
@@ -55,11 +51,7 @@ DM.provide('',
             }
         } else {  // destroy a single player
             if (DM.Player._INSTANCES[id] === undefined) {
-                try {
-                    if (console && typeof console.warn === 'function') {
-                        console.warn("Invalid first argument sent to DM.destroy(), requires a player id: " + id);
-                    }
-                } catch (e) {}
+                DM.warn("Invalid first argument sent to DM.destroy(), requires a player id: " + id);
                 return;
             }
 
@@ -297,22 +289,14 @@ DM.provide('Player',
     _send: function(command, parameters)
     {
         if (!this.apiReady) {
-            try {
-                if (console && typeof console.warn === 'function') {
-                    console.warn('Player not ready. Ignoring command : "'+command+'"');
-                }
-            } catch (e) {}
+            DM.warn('Player not ready. Ignoring command : "'+command+'"');
             return;
         }
 
         if (DM.Player.API_MODE == 'postMessage')
         {
             if (!this.contentWindow || typeof this.contentWindow.postMessage !== 'function') {
-                try {
-                    if (console && typeof console.warn === 'function') {
-                        console.warn('Player not reachable anymore. You may have destroyed it.');
-                    }
-                } catch (e) {}
+                DM.warn('Player not reachable anymore. You may have destroyed it.');
                 return;
             }
 

--- a/src/core/prelude.js
+++ b/src/core/prelude.js
@@ -226,6 +226,21 @@ if (!window.DM)
         },
 
         /**
+         * Display a warning message in console.
+         *
+         * @access private
+         * @param msg {string} message to warn in console
+         */
+        warn: function(msg)
+        {
+            try {
+                if (console && typeof console.warn === 'function') {
+                    console.warn(msg);
+                }
+            } catch (e) {}
+        },
+
+        /**
          * Shortcut for document.getElementById
          * @method $
          * @param {string} DOM id


### PR DESCRIPTION
## [<img src="http://svgshare.com/i/Gd.svg" height="16px"> PV-10264](https://jira.dailymotion.com/browse/PV-10264)

Regression of [PV-932](https://jira.dailymotion.com/browse/PV-932)
- destroy `player2` if it's not here => `warning`
- destroy `player1` and then button `play` => `warning`

![gotit](https://i.giphy.com/media/l2QZXuArmq2ihQEI8/giphy.webp)