### PR TITLE
PV-6969: fix apimode=queryString deserialization: replace `+` with a space in received payloads

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -278,6 +278,7 @@ DM.provide('Player',
     _decodePostMessage: function(rawMessage)
     {
       if (rawMessage.substring(0, 1) === '{') {
+        // apimode = json
         try {
           var data = JSON.parse(rawMessage);
           return data;
@@ -285,8 +286,10 @@ DM.provide('Player',
         catch(e) {
           return {};
         }
+      } else {
+        // apimode = queryString
+        return DM.QS.decode(rawMessage);
       }
-      return DM.QS.decode(rawMessage);
     },
 
     _send: function(command, parameters)

--- a/src/core/qs.js
+++ b/src/core/qs.js
@@ -66,7 +66,9 @@ DM.provide('QS',
     decode: function(str)
     {
         var qsParams = str.split('&');
-        var decode = decodeURIComponent;
+        var decode = function(string) {
+            return decodeURIComponent(string.replace(/\+/g, ' '));
+        }
 
         var params = {};
 

--- a/tests/js/qs.js
+++ b/tests/js/qs.js
@@ -50,11 +50,19 @@ test('decoding nested named value', function()
     ok(actual === expected);
 });
 
-test('decoding named value with spaces in name and value', function()
+test('decoding named value with spaces in name and value that were serialized as %20', function()
 {
     // a b c=d e f
     var encoded = 'a%20b%20c=d%20e%20f';
     var expected = JSON.stringify({ 'a b c': 'd e f' })
+    var actual = JSON.stringify(DM.QS.decode(encoded))
+    ok(actual === expected)
+});
+
+test('decoding value with spaces that was serialized as +', function()
+{
+    var encoded = 'user_agent=Mozilla%2F5.0+(Windows+NT+10.0%3B+Win64%3B+x64)+AppleWebKit%2F537.36+(KHTML%2C+like+Gecko)+Chrome%2F81.0.4044.122+Safari%2F537.36';
+    var expected = JSON.stringify({user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36'})
     var actual = JSON.stringify(DM.QS.decode(encoded))
     ok(actual === expected)
 });


### PR DESCRIPTION
In apimode=queryString on player side, events are serialized with `jquery.param()` method, which replaces spaces with `+`. We need to revert this serialization first before running through `decodeURIComponent`.