### PR TITLE
Ignore postMessage payloads that are not stringified

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -262,6 +262,7 @@ DM.provide('Player',
             {
                 var originDomain = e.origin ? e.origin.replace(/^https?:/, '') : null;
                 if (!originDomain || originDomain.indexOf(DM._domain.www) !== 0) return;
+                if (!e.data || typeof e.data !== 'string') return;
                 if (!DM.Player._IFRAME_ORIGIN) {
                   DM.Player._IFRAME_ORIGIN = e.origin;
                 }


### PR DESCRIPTION
The player `<iframe>` sends stringified payloads to the JS SDK through `postMessage`. They can be:

* JSON stringified payloads: `{"event":"apiready","id":"video-player-1"}`
* URL encoded payloads: `event=apiready&id=video-player-1`

If for some reason, we receive an other format (`Object` for instance), the payload sould be ignored.