### PR TITLE
Make the player's destroy method work without argument

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -188,6 +188,11 @@ DM.provide('Player',
 
     destroy: function(id)
     {
+        // Use the player's id by default
+        if (!id) {
+            id = this.id;
+        }
+
         var player = DM.Player._INSTANCES[id];
         var anchor = DM.Player._ANCHORS[id];
 


### PR DESCRIPTION
At the moment, one needs to provide the player's id: `player.destroy(id)`. With this change, the argument is no longer necessary. This allows to destroy the player when its id is not known (for instance, when the id has been internally generated by the library).