### PR TITLE
expose adData during ad_start event

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -103,6 +103,7 @@ DM.provide('Player',
     video: null,
     companionAds: null,
     loop: false,
+    adData: {},
 
     play: function() {this.api('play');},
     togglePlay: function() {this.api('toggle-play');},
@@ -369,7 +370,7 @@ DM.provide('Player',
             case 'playing':
             case 'play': this.paused = false; break;
             case 'end': this.ended = true; break; // no break, also set paused
-            case 'ad_end': this.adData = null;
+            case 'ad_end': this.adData = {};
             case 'ad_pause':
             case 'video_end':
             case 'pause': this.paused = true; break;

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -363,14 +363,14 @@ DM.provide('Player',
             case 'fullscreenchange': this.fullscreen = DM.parseBool(event.fullscreen); break;
             case 'controlschange': this.controls = DM.parseBool(event.controls); break;
             case 'volumechange': this.volume = parseFloat(event.volume); this.muted = DM.parseBool(event.muted); break;
+            case 'ad_start': this.adData = event.adData;
             case 'video_start':
-            case 'ad_start':
             case 'ad_play':
             case 'playing':
             case 'play': this.paused = false; break;
             case 'end': this.ended = true; break; // no break, also set paused
+            case 'ad_end': this.adData = null;
             case 'ad_pause':
-            case 'ad_end':
             case 'video_end':
             case 'pause': this.paused = true; break;
             case 'error': this.error = {code: event.code, title: event.title, message: event.message}; break;


### PR DESCRIPTION
During `ad_start` event, the `adData` Object is available in the `player` instance

- create a Player
```
<div id="player"></div>
<script src="https://api.dmcdn.net/all.js"></script>

const player = DM.player('player', { video: 'x730nnd' })
```

- attach the listener to it
```
player.addEventListener('ad_start', () => {
  console.log(player.adData)
})
```
=> as soon as the ad is displayed, you'll have the `adData` informations in the `player` instance
