### PR TITLE
ads_params convertion to cust_params

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -120,6 +120,7 @@ DM.provide('Player',
     toggleControls: function () { this.api('toggle-controls');},
     setProp: function() {this.api.apply(this, ['set-prop'].concat([].slice.call(arguments)));}, // onsite use only
     setAdsConfig: function (config) {this.api("set-ads-config", config);},
+    setCustConfig: function (config) {this.api("set-ads-config", config);},
     watchOnSite: function(muted) {this.api('watch-on-site');},
     setLoop: function (loop) { this.api('loop', loop);},
 
@@ -235,6 +236,12 @@ DM.provide('Player',
         if (DM._apiKey)
         {
             params.apiKey = DM._apiKey;
+        }
+
+        // ads_params (deprecated) convertion to cust_params
+        if (params.ads_params && !params.cust_params) {
+            params.cust_params = params.ads_params
+            delete params.ads_params
         }
 
         if (video && playlist) {

--- a/tests/player.html
+++ b/tests/player.html
@@ -152,7 +152,9 @@
         function createPlayer(id) {
             player = DM.player(document.getElementById(id), {
                 video,
-                params: {},
+                params: {
+                  ads_params: 'must_be_cust_params',
+                },
                 referrerPolicy: 'no-referrer-when-downgrade',
                 events: {
                     play: function() { console.log('play'); },


### PR DESCRIPTION
To prevent `ads_params` parameter to be restricted by ad-blockers in the iframe Query String, we choose to rename it `cust_params`
We keep the retrocompatibility with previous parameters to not break existing integrations

### TODO
- [x] ads_params is converted to cust_params on iframe creation (see example below)
- [x] add `setCustConfig` method (keep `setAdsConfig` for retrocompat)


### TEST IT

The code below should provide an <iframe> with `cust_params=must_be_cust_params` in its query string
```
player = DM.player(document.getElementById('myPlayer'), {
	  video: 'xwr14q',
	  params: {
	    ads_params: 'must_be_cust_params',
	  }
}
```
