### PR TITLE
Revert cust_params support

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -238,12 +238,6 @@ DM.provide('Player',
             params.apiKey = DM._apiKey;
         }
 
-        // ads_params (deprecated) convertion to cust_params
-        if (params.ads_params && !params.cust_params) {
-            params.cust_params = params.ads_params
-            delete params.ads_params
-        }
-
         if (video && playlist) {
             params.playlist = playlist;
         }

--- a/tests/player.html
+++ b/tests/player.html
@@ -152,9 +152,7 @@
         function createPlayer(id) {
             player = DM.player(document.getElementById(id), {
                 video,
-                params: {
-                  ads_params: 'must_be_cust_params',
-                },
+                params: {},
                 referrerPolicy: 'no-referrer-when-downgrade',
                 events: {
                     play: function() { console.log('play'); },


### PR DESCRIPTION
In #98 we introduced a new mechanism to convert the legacy `ads_params` to the new `cust_params` syntax.

This had some unwanted effects on Chrome, so we need to revert this change for now.

The `player.setCustConfig()` method stays though, as its removal would be a breaking change.