### PR TITLE
Upgrade node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.6.0
+FROM node:18.19.1
 
 LABEL maintainer "Player Squad <squad-player@dailymotion.com>"
 


### PR DESCRIPTION
Upgrade to latest LTS to fix release issue:
```
Service 'app' failed to build: The command '/bin/sh -c apt-get update && apt-get install -y java-common default-jre-headless java-wrappers libjargs-java' returned a non-zero code: 100

Makefile:29: recipe for target 'build' failed
```